### PR TITLE
CocoaPods support

### DIFF
--- a/Formatting.podspec
+++ b/Formatting.podspec
@@ -1,0 +1,21 @@
+Pod::Spec.new do |s|
+  s.name             = 'Formatting'
+  s.version          = '0.1.1'
+  s.summary          = 'Formatted Localizable Strings'
+
+ 
+  s.description      = <<-DESC
+An example code for kean.blog: Formatted Localizable Strings. Demonstrates how to implement basic string formatting using XML tags.
+                       DESC
+
+  s.homepage         = 'https://github.com/kean/Formatting'
+  s.license          = { :type => 'MIT', :file => 'LICENSE' }
+  s.author           = { 'Alexander Grebenyuk' => 'https://kean.blog' }
+  s.source           = { :git => 'https://github.com/kean/Formatting.git', :tag => s.version.to_s }
+
+  s.ios.deployment_target = '11.0'
+  s.swift_version = '5.3'
+
+  s.source_files = 'Source/**/*.swift'
+
+end

--- a/Formatting.podspec
+++ b/Formatting.podspec
@@ -14,6 +14,10 @@ An example code for kean.blog: Formatted Localizable Strings. Demonstrates how t
   s.source           = { :git => 'https://github.com/kean/Formatting.git', :tag => s.version.to_s }
 
   s.ios.deployment_target = '11.0'
+  s.osx.deployment_target = '10.13'
+  s.watchos.deployment_target = '4.0'
+  s.tvos.deployment_target = '11.0'
+
   s.swift_version = '5.3'
 
   s.source_files = 'Source/**/*.swift'

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Alexander Grebenyuk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Source/Formatting.swift
+++ b/Source/Formatting.swift
@@ -3,7 +3,13 @@
 // Copyright (c) 2020 Alexander Grebenyuk (github.com/kean).
 
 import Foundation
+#if !os(macOS)
 import UIKit
+#else
+import AppKit
+#endif
+
+
 
 public extension NSAttributedString {
     /// Initializes the string with the given formatted string.


### PR DESCRIPTION
#### What's done

[ADDED] .podspec file
[ADDED] MIT LICENSE file
[FIXED] MacOS build error via UIKit/AppKit conditional import

#### Notes
- I've added `.podspec` file to be able to integrate Formatting via CocoaPods.
- Podspec file was validated via `pod lib lint `. 
- License file is a github's MIT LICENSE template, that was added to suppress pod lint's warnings of missing license.
- Without conditional import of UIKit/AppKit, the package won't build for MacOS